### PR TITLE
Add StbSharp to performance test

### DIFF
--- a/Sources/Epsylon.TextureSquish.UnitTests/Epsylon.TextureSquish.UnitTests.csproj
+++ b/Sources/Epsylon.TextureSquish.UnitTests/Epsylon.TextureSquish.UnitTests.csproj
@@ -48,7 +48,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0002" />    
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0002" />
+    <PackageReference Include="StbSharp" Version="0.4.7.25" />    
   </ItemGroup>
 
   <ItemGroup>    

--- a/Sources/Epsylon.TextureSquish.UnitTests/UnitTest1.cs
+++ b/Sources/Epsylon.TextureSquish.UnitTests/UnitTest1.cs
@@ -1,6 +1,5 @@
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using SixLabors.ImageSharp;
 
 namespace Epsylon.TextureSquish.UnitTests
 {
@@ -44,8 +43,10 @@ namespace Epsylon.TextureSquish.UnitTests
         public void PerformanceTest1()
         {
             var srcImg = SixLabors.ImageSharp.Image.Load("TestFiles\\Rainbow_to_alpha_gradient_large.png");
-
             var toSquish = srcImg.ToSquishImage();
+            StbSharp.Image image;
+            using (var stream = File.OpenRead("TestFiles\\Rainbow_to_alpha_gradient_large.png"))
+                image = new StbSharp.ImageReader().Read(stream);
 
             var watch = new System.Diagnostics.Stopwatch();
 
@@ -68,6 +69,26 @@ namespace Epsylon.TextureSquish.UnitTests
             netTime = watch.Elapsed;
 
             TestContext.WriteLine($"ClusterFit Alt time: {netTime}");
+
+            watch.Restart();
+            for (int i = 0; i < 100; ++i)
+            {
+                StbSharp.Stb.stb_compress_dxt(image, true);
+            }
+            watch.Stop();
+            var stbTime = watch.Elapsed;
+
+            TestContext.WriteLine($"Stb time: {stbTime}");
+
+            watch.Restart();
+            for (int i = 0; i < 100; ++i)
+            {
+                StbSharp.Stb.stb_compress_dxt(image, true, 2);
+            }
+            watch.Stop();
+            var stbHqTime = watch.Elapsed;
+
+            TestContext.WriteLine($"Stb HQ time: {stbHqTime}");
 
             watch.Restart();
             for (int i = 0; i < 100; ++i)


### PR DESCRIPTION
As requested this adds StbSharp.Stb.Dxt to the performance tests. Note that the mode flag is not exposed very nicely. If `mode & 1 != 0` dithering will be used; if `mode & 2 != 0` the result will be refined twice instead of once, called high quality in the stb_dxt source code (I don't know what this means, but you probably do).

Timings on my machine are as follows:
- ClusterFit Iterative time: 00:00:31.5659040
- ClusterFit Alt time: 00:00:37.8720331
- Stb time: 00:00:11.7758094
- Stb HQ time: 00:00:12.2313995 (does not seem to matter for performance?)
- NVidia time: 00:00:14.3456973